### PR TITLE
Release 1.0.0-beta1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,8 +7,31 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>1.0.0</VersionPrefix>
-    <PackageReleaseNotes>Example release notes</PackageReleaseNotes>
+    <VersionPrefix>1.0.0-beta1</VersionPrefix>
+    <PackageReleaseNotes>Initial beta release of the completely rewritten GoToWebinar CLI
+
+**New Architecture:**
+- Modern .NET 9 runtime with AOT compilation for improved performance
+- Complete rewrite removing legacy dependencies and technical debt
+- Cross-platform support with optimized native binaries
+
+**Features:**
+- OAuth2 authentication with secure credential storage
+- Self-update functionality with automatic version checking  
+- Core webinar management commands (list, details, create)
+- Registrant export capabilities with flexible formatting
+- API rate limiting for GoToWebinar compliance
+- Improved installation scripts for streamlined setup
+- Configuration management for API credentials
+
+**Technical Improvements:**
+- Native AOT compilation for faster startup and smaller memory footprint
+- Enhanced error handling and user experience
+- Streamlined build and deployment process
+
+**Known Issues:**
+- This is a beta release for testing and feedback
+- Some advanced features may be added in future releases</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Visual Studio C# settings -->
@@ -24,7 +47,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
   </ItemGroup>
   <!-- NuGet package properties -->
-    <ItemGroup>
+  <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)\akkalogo.png" Pack="true" PackagePath="\" />
     <None Include="$(MSBuildThisFileDirectory)\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,32 @@
+#### 1.0.0-beta1 September 2nd 2025 ####
+
+Initial beta release of the completely rewritten GoToWebinar CLI
+
+**New Architecture:**
+- Modern .NET 9 runtime with AOT compilation for improved performance
+- Complete rewrite removing legacy dependencies and technical debt
+- Cross-platform support with optimized native binaries
+
+**Features:**
+- OAuth2 authentication with secure credential storage
+- Self-update functionality with automatic version checking  
+- Core webinar management commands (list, details, create)
+- Registrant export capabilities with flexible formatting
+- API rate limiting for GoToWebinar compliance
+- Improved installation scripts for streamlined setup
+- Configuration management for API credentials
+
+**Technical Improvements:**
+- Native AOT compilation for faster startup and smaller memory footprint
+- Enhanced error handling and user experience
+- Streamlined build and deployment process
+
+**Known Issues:**
+- This is a beta release for testing and feedback
+- Some advanced features may be added in future releases
+
+---
+
 #### 0.1.0-beta1 August 29th 2025 ####
 
 Initial beta release of GoToWebinar CLI


### PR DESCRIPTION
## Summary
Prepare for the initial beta release of the GoToWebinar CLI v1.0.0-beta1.

### Changes
- Updated version to 1.0.0-beta1 in Directory.Build.props
- Added comprehensive release notes documenting the complete rewrite
- Included details about new .NET 9 architecture with AOT compilation
- Documented OAuth2 authentication, self-update functionality, and core features

### Release Highlights
- Modern .NET 9 runtime with AOT compilation for improved performance
- Complete rewrite removing legacy dependencies and technical debt
- Cross-platform support with optimized native binaries
- OAuth2 authentication with secure credential storage
- Self-update functionality with automatic version checking
- Core webinar management commands and registrant export capabilities

This PR prepares the codebase for the beta release tag creation and deployment.