### PR TITLE
Fix release workflow to handle both tag formats

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*'
+      - '[0-9]*'
 
 permissions:
   contents: write
@@ -19,7 +20,9 @@ jobs:
       - name: Get version from tag
         id: get_version
         run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
+          # Remove 'v' prefix if present, otherwise use tag as-is
+          TAG=${GITHUB_REF#refs/tags/}
+          VERSION=${TAG#v}
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           # Check if this is a prerelease (contains beta, alpha, rc, etc.)
           if [[ "$VERSION" =~ (beta|alpha|rc|preview) ]]; then


### PR DESCRIPTION
This PR fixes the GitHub Actions release workflow to handle tags both with and without the 'v' prefix.

## Changes
- Updated workflow trigger to match tags starting with 'v' OR starting with numbers
- Modified version extraction logic to handle both 'v1.0.0' and '1.0.0' tag formats

## Why
The release workflow was only triggered by tags with 'v' prefix, but our release tooling creates numeric tags without the prefix. This caused the release binaries not to be built and uploaded.

## Testing
After this is merged, we'll recreate the v1.0.0-beta1 tag which will trigger the workflow and build/upload all platform binaries.