### PR TITLE
Hotfix: PowerShell multiline command in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,14 +105,7 @@ jobs:
         Set-Content -Path $csprojPath -Value $content
         
     - name: Build and Publish AOT
-      run: |
-        dotnet publish src/GoToWebinarCLI/GoToWebinarCLI.csproj \
-          -c Release \
-          -r ${{ matrix.runtime }} \
-          --self-contained \
-          -p:PublishAot=true \
-          -p:Version=${{ needs.create-release.outputs.version }} \
-          -o ./publish
+      run: dotnet publish src/GoToWebinarCLI/GoToWebinarCLI.csproj -c Release -r ${{ matrix.runtime }} --self-contained -p:PublishAot=true -p:Version=${{ needs.create-release.outputs.version }} -o ./publish
           
     - name: Compress binary (Linux/macOS)
       if: matrix.os != 'windows-latest'


### PR DESCRIPTION
## Critical Fix
The release workflow is failing on Windows due to PowerShell not handling multiline commands with backslashes properly.

## Error
```
ParserError: Missing expression after unary operator '--'.
```

## Solution
Put the entire dotnet publish command on a single line to avoid PowerShell parsing issues.

## Impact
This is blocking the v1.0.0-beta1 release from building binaries.