### PR TITLE
Fix update service to use GitHub Releases API

### DIFF
--- a/src/GoToWebinarCLI/GoToWebinarJsonContext.cs
+++ b/src/GoToWebinarCLI/GoToWebinarJsonContext.cs
@@ -34,8 +34,6 @@ namespace GoToWebinarCLI;
 [JsonSerializable(typeof(List<Webinar>), TypeInfoPropertyName = "ListWebinar")]
 [JsonSerializable(typeof(List<Registrant>), TypeInfoPropertyName = "ListRegistrant")]
 [JsonSerializable(typeof(UpdateInfo))]
-[JsonSerializable(typeof(VersionManifest))]
-[JsonSerializable(typeof(DownloadUrls))]
 public partial class GoToWebinarJsonContext : JsonSerializerContext
 {
 }

--- a/src/GoToWebinarCLI/Services/UpdateService.cs
+++ b/src/GoToWebinarCLI/Services/UpdateService.cs
@@ -15,7 +15,7 @@ public sealed class UpdateService
     {
         _httpClient = httpClient;
         _currentVersion = currentVersion;
-        
+
         // Add User-Agent header required by GitHub API
         if (!_httpClient.DefaultRequestHeaders.Contains("User-Agent"))
         {
@@ -29,7 +29,7 @@ public sealed class UpdateService
         {
             var response = await _httpClient.GetStringAsync(GitHubApiUrl);
             var releaseJson = JsonNode.Parse(response);
-            
+
             if (releaseJson == null)
                 return null;
 
@@ -39,7 +39,7 @@ public sealed class UpdateService
 
             // Remove 'v' prefix if present
             var version = tagName.StartsWith("v") ? tagName.Substring(1) : tagName;
-            
+
             // Parse current version to handle versions with build metadata (e.g., "1.0.0-beta1+hash")
             var currentVersionClean = _currentVersion.Split('+')[0];
 
@@ -206,7 +206,7 @@ public sealed class UpdateService
                 return true;
             if (!string.IsNullOrEmpty(newParts.PreRelease) && string.IsNullOrEmpty(currentParts.PreRelease))
                 return false;
-            
+
             // If both have pre-release, compare them
             if (!string.IsNullOrEmpty(newParts.PreRelease) && !string.IsNullOrEmpty(currentParts.PreRelease))
             {
@@ -228,7 +228,7 @@ public sealed class UpdateService
         var preRelease = dashIndex >= 0 ? version.Substring(dashIndex + 1) : "";
 
         var parts = majorPart.Split('.').Select(p => int.TryParse(p, out var num) ? num : 0).ToArray();
-        
+
         // Ensure we have at least 3 parts (major.minor.patch)
         var major = new int[3];
         for (int i = 0; i < Math.Min(parts.Length, 3); i++)

--- a/src/GoToWebinarCLI/Services/UpdateService.cs
+++ b/src/GoToWebinarCLI/Services/UpdateService.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 
 namespace GoToWebinarCLI.Services;
 
@@ -8,43 +9,82 @@ public sealed class UpdateService
 {
     private readonly HttpClient _httpClient;
     private readonly string _currentVersion;
-    private const string VersionManifestUrl = "https://raw.githubusercontent.com/stannardlabs/gotowebinar-cli/main/version.json";
+    private const string GitHubApiUrl = "https://api.github.com/repos/stannardlabs/gotowebinar-cli/releases/latest";
 
     public UpdateService(HttpClient httpClient, string currentVersion)
     {
         _httpClient = httpClient;
         _currentVersion = currentVersion;
+        
+        // Add User-Agent header required by GitHub API
+        if (!_httpClient.DefaultRequestHeaders.Contains("User-Agent"))
+        {
+            _httpClient.DefaultRequestHeaders.Add("User-Agent", "GoToWebinar-CLI");
+        }
     }
 
     public async Task<UpdateInfo?> CheckForUpdateAsync()
     {
         try
         {
-            var response = await _httpClient.GetStringAsync(VersionManifestUrl);
-            var manifest = JsonSerializer.Deserialize(response, GoToWebinarJsonContext.Default.VersionManifest);
-
-            if (manifest == null || string.IsNullOrEmpty(manifest.Version))
+            var response = await _httpClient.GetStringAsync(GitHubApiUrl);
+            var releaseJson = JsonNode.Parse(response);
+            
+            if (releaseJson == null)
                 return null;
 
-            if (IsNewerVersion(manifest.Version, _currentVersion))
+            var tagName = releaseJson["tag_name"]?.ToString();
+            if (string.IsNullOrEmpty(tagName))
+                return null;
+
+            // Remove 'v' prefix if present
+            var version = tagName.StartsWith("v") ? tagName.Substring(1) : tagName;
+            
+            // Parse current version to handle versions with build metadata (e.g., "1.0.0-beta1+hash")
+            var currentVersionClean = _currentVersion.Split('+')[0];
+
+            if (IsNewerVersion(version, currentVersionClean))
             {
                 var platform = GetCurrentPlatform();
-                var downloadUrl = platform switch
+                var assetName = platform switch
                 {
-                    "linux-x64" => manifest.Downloads?.LinuxX64,
-                    "win-x64" => manifest.Downloads?.WinX64,
-                    "osx-x64" => manifest.Downloads?.OsxX64,
+                    "linux-x64" => "gotowebinar-linux-x64.tar.gz",
+                    "win-x64" => "gotowebinar-win-x64.exe.zip",
+                    "osx-x64" => "gotowebinar-osx-x64.tar.gz",
                     _ => null
                 };
 
-                if (downloadUrl != null)
+                if (assetName == null)
+                    return null;
+
+                // Find the matching asset
+                var assets = releaseJson["assets"]?.AsArray();
+                if (assets != null)
                 {
-                    return new UpdateInfo
+                    foreach (var asset in assets)
                     {
-                        Version = manifest.Version,
-                        DownloadUrl = downloadUrl,
-                        ReleaseDate = manifest.ReleaseDate
-                    };
+                        if (asset?["name"]?.ToString() == assetName)
+                        {
+                            var downloadUrl = asset["browser_download_url"]?.ToString();
+                            if (!string.IsNullOrEmpty(downloadUrl))
+                            {
+                                var releaseDateStr = releaseJson["published_at"]?.ToString();
+                                DateTime? releaseDate = null;
+                                if (!string.IsNullOrEmpty(releaseDateStr))
+                                {
+                                    DateTime.TryParse(releaseDateStr, out var parsedDate);
+                                    releaseDate = parsedDate;
+                                }
+
+                                return new UpdateInfo
+                                {
+                                    Version = version,
+                                    DownloadUrl = downloadUrl,
+                                    ReleaseDate = releaseDate
+                                };
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -149,16 +189,28 @@ public sealed class UpdateService
     {
         try
         {
-            var newParts = newVersion.Split('.').Select(int.Parse).ToArray();
-            var currentParts = currentVersion.Split('.').Select(int.Parse).ToArray();
+            // Handle semantic versioning with pre-release tags (e.g., 1.0.0-beta1)
+            var newParts = ParseVersion(newVersion);
+            var currentParts = ParseVersion(currentVersion);
 
-            for (int i = 0; i < Math.Max(newParts.Length, currentParts.Length); i++)
+            // Compare major.minor.patch first
+            for (int i = 0; i < 3; i++)
             {
-                var newPart = i < newParts.Length ? newParts[i] : 0;
-                var currentPart = i < currentParts.Length ? currentParts[i] : 0;
+                if (newParts.Major[i] > currentParts.Major[i]) return true;
+                if (newParts.Major[i] < currentParts.Major[i]) return false;
+            }
 
-                if (newPart > currentPart) return true;
-                if (newPart < currentPart) return false;
+            // If major.minor.patch are the same, compare pre-release
+            // No pre-release is considered newer than any pre-release
+            if (string.IsNullOrEmpty(newParts.PreRelease) && !string.IsNullOrEmpty(currentParts.PreRelease))
+                return true;
+            if (!string.IsNullOrEmpty(newParts.PreRelease) && string.IsNullOrEmpty(currentParts.PreRelease))
+                return false;
+            
+            // If both have pre-release, compare them
+            if (!string.IsNullOrEmpty(newParts.PreRelease) && !string.IsNullOrEmpty(currentParts.PreRelease))
+            {
+                return string.Compare(newParts.PreRelease, currentParts.PreRelease, StringComparison.OrdinalIgnoreCase) > 0;
             }
 
             return false;
@@ -167,6 +219,24 @@ public sealed class UpdateService
         {
             return false;
         }
+    }
+
+    private static (int[] Major, string PreRelease) ParseVersion(string version)
+    {
+        var dashIndex = version.IndexOf('-');
+        var majorPart = dashIndex >= 0 ? version.Substring(0, dashIndex) : version;
+        var preRelease = dashIndex >= 0 ? version.Substring(dashIndex + 1) : "";
+
+        var parts = majorPart.Split('.').Select(p => int.TryParse(p, out var num) ? num : 0).ToArray();
+        
+        // Ensure we have at least 3 parts (major.minor.patch)
+        var major = new int[3];
+        for (int i = 0; i < Math.Min(parts.Length, 3); i++)
+        {
+            major[i] = parts[i];
+        }
+
+        return (major, preRelease);
     }
 
     private static string ExtractZipFile(string zipPath)
@@ -200,18 +270,4 @@ public sealed class UpdateInfo
     public string Version { get; set; } = "";
     public string DownloadUrl { get; set; } = "";
     public DateTime? ReleaseDate { get; set; }
-}
-
-public sealed class VersionManifest
-{
-    public string Version { get; set; } = "";
-    public DateTime? ReleaseDate { get; set; }
-    public DownloadUrls? Downloads { get; set; }
-}
-
-public sealed class DownloadUrls
-{
-    public string? LinuxX64 { get; set; }
-    public string? WinX64 { get; set; }
-    public string? OsxX64 { get; set; }
 }


### PR DESCRIPTION
## Summary
- Fixed the update service to properly check for updates using GitHub Releases API
- Replaced non-existent version.json endpoint with GitHub's releases API
- Improved version comparison logic to handle semantic versioning with pre-release tags

## Changes
- Updated `UpdateService.cs` to:
  - Use GitHub Releases API endpoint instead of version.json
  - Add User-Agent header required by GitHub API
  - Parse release assets correctly with proper naming conventions
  - Implement semantic versioning comparison with pre-release support
- Removed unused `VersionManifest` and `DownloadUrls` classes
- Updated `GoToWebinarJsonContext.cs` to remove serialization of removed classes

## Problem Fixed
The update check was failing with a 404 error because it was trying to fetch a non-existent `version.json` file from the repository. The service now correctly queries GitHub's Releases API to check for updates.

## Test Plan
- [x] Build passes without errors
- [x] Update check will correctly identify newer versions
- [x] Version comparison handles pre-release versions (beta, alpha, etc.)
- [x] Asset names match actual release artifacts