### PR TITLE
Prepare release 1.0.0-beta3

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,23 +7,20 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>1.0.0-beta2</VersionPrefix>
-    <PackageReleaseNotes>Major feature expansion with complete webinar and registrant management functionality
+    <VersionPrefix>1.0.0-beta3</VersionPrefix>
+    <PackageReleaseNotes>Critical update service fix with improved reliability
 
-**New Features:**
-- **Complete webinar management commands** - Full CRUD operations for webinars
-- **Complete registrant management commands** - Comprehensive registrant handling
-- **Multiple output formats** - Support for table, JSON, and CSV output formats
-- **Comprehensive API credential documentation** - Step-by-step guide for obtaining GoToWebinar API credentials
+**Bug Fixes:**
+- **Fixed update service to use GitHub Releases API** - Resolved update check failures caused by non-existent version.json endpoint (#17)
+  - Now correctly queries GitHub's Releases API for version checks
+  - Added proper User-Agent header required by GitHub API
+  - Improved semantic versioning comparison with pre-release support
+  - Fixed asset names to match actual release artifacts
+  - Removed unused VersionManifest and DownloadUrls classes
 
-**Improvements:**
-- **Enhanced command usability** - Replaced confusing --upcoming flag with clearer --all and --past flags
-- **Robust testing infrastructure** - Added 16 unit tests with Moq and FluentAssertions for comprehensive coverage
-- **AOT compilation compatibility** - Ensured all new commands work with native AOT compilation
-
-**Security Updates:**
-- Updated Microsoft.Extensions.Http.Polly from 9.0.0 to 9.0.8
-- Updated System.Security.Cryptography.ProtectedData from 9.0.0 to 9.0.8</PackageReleaseNotes>
+**Technical Improvements:**
+- Enhanced version comparison logic to properly handle beta, alpha, and other pre-release tags
+- Streamlined update service architecture for better maintainability</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Visual Studio C# settings -->

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,21 @@
+#### 1.0.0-beta3 September 2nd 2025 ####
+
+Critical update service fix with improved reliability
+
+**Bug Fixes:**
+- **Fixed update service to use GitHub Releases API** - Resolved update check failures caused by non-existent version.json endpoint ([#17](https://github.com/Aaronontheweb/gotowebinar-cli/pull/17))
+  - Now correctly queries GitHub's Releases API for version checks
+  - Added proper User-Agent header required by GitHub API
+  - Improved semantic versioning comparison with pre-release support
+  - Fixed asset names to match actual release artifacts
+  - Removed unused VersionManifest and DownloadUrls classes
+
+**Technical Improvements:**
+- Enhanced version comparison logic to properly handle beta, alpha, and other pre-release tags
+- Streamlined update service architecture for better maintainability
+
+---
+
 #### 1.0.0-beta2 September 2nd 2025 ####
 
 Major feature expansion with complete webinar and registrant management functionality


### PR DESCRIPTION
## Release 1.0.0-beta3

### 🎯 Key Highlight
**Fixed critical update service** - The CLI can now properly check for and install updates from GitHub releases!

### Summary
This release fixes the critical update service that was failing with 404 errors. The update functionality now properly uses the GitHub Releases API to check for new versions and download updates.

### Changes since 1.0.0-beta2
- 🔧 **Fix update service to use GitHub Releases API** (#17)
  - Replaced non-existent version.json endpoint with GitHub Releases API
  - Added proper semantic versioning support with pre-release handling
  - Fixed asset names to match actual release artifacts
  - Added required User-Agent header for GitHub API

### Technical Improvements
- Removed unused VersionManifest and DownloadUrls classes
- Improved version comparison logic to handle pre-release tags
- Enhanced error handling in update service

### Testing
- [x] Build passes on all platforms
- [x] Update service correctly identifies new versions
- [x] Version comparison properly handles semantic versioning
- [x] Asset downloads work correctly

The GitHub Actions workflow will automatically create the release after this PR is merged.