### PR TITLE
Update repository references to new organization

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -12,7 +12,7 @@ param(
 $ErrorActionPreference = "Stop"
 
 # Configuration
-$Repo = "stannardlabs/gotowebinar-cli"
+$Repo = "Aaronontheweb/gotowebinar-cli"
 $Platform = "win-x64"
 
 # Colors for output

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,7 +5,7 @@ set -e
 # GoToWebinar CLI Installation Script
 # This script downloads and installs the GoToWebinar CLI tool
 
-REPO="stannardlabs/gotowebinar-cli"
+REPO="Aaronontheweb/gotowebinar-cli"
 INSTALL_DIR="/usr/local/bin"
 BINARY_NAME="gotowebinar"
 

--- a/src/GoToWebinarCLI/Services/UpdateService.cs
+++ b/src/GoToWebinarCLI/Services/UpdateService.cs
@@ -9,7 +9,7 @@ public sealed class UpdateService
 {
     private readonly HttpClient _httpClient;
     private readonly string _currentVersion;
-    private const string GitHubApiUrl = "https://api.github.com/repos/stannardlabs/gotowebinar-cli/releases/latest";
+    private const string GitHubApiUrl = "https://api.github.com/repos/Aaronontheweb/gotowebinar-cli/releases";
 
     public UpdateService(HttpClient httpClient, string currentVersion)
     {
@@ -28,7 +28,13 @@ public sealed class UpdateService
         try
         {
             var response = await _httpClient.GetStringAsync(GitHubApiUrl);
-            var releaseJson = JsonNode.Parse(response);
+            var releasesJson = JsonNode.Parse(response)?.AsArray();
+            
+            if (releasesJson == null || releasesJson.Count == 0)
+                return null;
+
+            // Get the first release (most recent, including pre-releases)
+            var releaseJson = releasesJson[0];
 
             if (releaseJson == null)
                 return null;

--- a/src/GoToWebinarCLI/Services/UpdateService.cs
+++ b/src/GoToWebinarCLI/Services/UpdateService.cs
@@ -29,7 +29,7 @@ public sealed class UpdateService
         {
             var response = await _httpClient.GetStringAsync(GitHubApiUrl);
             var releasesJson = JsonNode.Parse(response)?.AsArray();
-            
+
             if (releasesJson == null || releasesJson.Count == 0)
                 return null;
 


### PR DESCRIPTION
## Summary
- Updated installation scripts to reference new repository location
- Modified UpdateService to fetch all releases from GitHub API

## Changes
- Updated PowerShell and Bash installation scripts to use `Aaronontheweb/gotowebinar-cli` repository
- Changed UpdateService API endpoint to fetch releases array instead of just latest release
- Added logic to handle array of releases and select the most recent one

## Test Plan
- [ ] Verify installation scripts work with new repository location
- [ ] Confirm update service correctly fetches and processes releases
- [ ] Test that version checking works as expected