### PR TITLE
Fix OAuth redirect port documentation and improve auth help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To use this CLI, you'll need to obtain API credentials from GoToWebinar:
      - **Product**: Select "GoToWebinar"
      - **Application Name**: Enter a name for your application
      - **Application Description**: Provide a brief description
-     - **Redirect URIs**: Add `http://localhost:8080/callback` (required for CLI authentication)
+     - **Redirect URIs**: Add `http://localhost:7878/callback` (required for CLI authentication)
    
 3. **Obtain Your Credentials**:
    - Once created, you'll receive:

--- a/src/GoToWebinarCLI/Commands/ConfigCommand.cs
+++ b/src/GoToWebinarCLI/Commands/ConfigCommand.cs
@@ -11,7 +11,7 @@ public sealed class ConfigCommand : Command
     {
         Description = "Configure API credentials, authenticate with GoToWebinar, and manage configuration profiles. " +
                      "Get your OAuth credentials from https://developer.goto.com/oauth-clients";
-        
+
         var setCommand = new Command("set", "Set GoToWebinar OAuth credentials")
         {
             Description = "Configure your OAuth Client ID and Client Secret obtained from the GoTo Developer Center. " +

--- a/src/GoToWebinarCLI/Commands/ConfigCommand.cs
+++ b/src/GoToWebinarCLI/Commands/ConfigCommand.cs
@@ -7,12 +7,19 @@ namespace GoToWebinarCLI.Commands;
 
 public sealed class ConfigCommand : Command
 {
-    public ConfigCommand() : base("config", "Manage GoToWebinar CLI configuration")
+    public ConfigCommand() : base("config", "Manage GoToWebinar CLI configuration and authentication")
     {
-        var setCommand = new Command("set", "Set configuration values");
-        var clientIdOption = new Option<string>("--client-id", "OAuth Client ID");
-        var clientSecretOption = new Option<string>("--client-secret", "OAuth Client Secret");
-        var profileOption = new Option<string>("--profile", () => "default", "Configuration profile name");
+        Description = "Configure API credentials, authenticate with GoToWebinar, and manage configuration profiles. " +
+                     "Get your OAuth credentials from https://developer.goto.com/oauth-clients";
+        
+        var setCommand = new Command("set", "Set GoToWebinar OAuth credentials")
+        {
+            Description = "Configure your OAuth Client ID and Client Secret obtained from the GoTo Developer Center. " +
+                         "Both credentials are required before you can authenticate."
+        };
+        var clientIdOption = new Option<string>("--client-id", "OAuth Client ID from GoTo Developer Center");
+        var clientSecretOption = new Option<string>("--client-secret", "OAuth Client Secret from GoTo Developer Center");
+        var profileOption = new Option<string>("--profile", () => "default", "Configuration profile name (for managing multiple accounts)");
 
         setCommand.AddOption(clientIdOption);
         setCommand.AddOption(clientSecretOption);
@@ -23,26 +30,51 @@ public sealed class ConfigCommand : Command
             await SetConfigAsync(clientId, clientSecret, profile);
         }, clientIdOption, clientSecretOption, profileOption);
 
-        var testCommand = new Command("test", "Test API connection");
+        var testCommand = new Command("test", "Test your GoToWebinar API connection")
+        {
+            Description = "Verifies that your credentials are configured and your authentication token is valid. " +
+                         "Shows token expiration time and organizer information if available."
+        };
         testCommand.SetHandler(async () => await TestConnectionAsync());
 
-        var getCommand = new Command("get", "Show current configuration");
+        var getCommand = new Command("get", "Display current configuration settings")
+        {
+            Description = "Shows your current profile, API credentials (masked), authentication status, " +
+                         "and other configuration settings like default format and page size."
+        };
         getCommand.SetHandler(async () => await ShowConfigAsync());
 
-        var profilesCommand = new Command("profiles", "Manage configuration profiles");
+        var profilesCommand = new Command("profiles", "Manage multiple GoToWebinar account profiles")
+        {
+            Description = "Create and switch between different configuration profiles to manage multiple GoToWebinar accounts. " +
+                         "Each profile maintains its own credentials and authentication tokens."
+        };
 
-        var listProfilesCommand = new Command("list", "List all profiles");
+        var listProfilesCommand = new Command("list", "List all configured profiles")
+        {
+            Description = "Shows all available profiles, marking the current active profile with an asterisk (*) " +
+                         "and indicating authentication status for each."
+        };
         listProfilesCommand.SetHandler(async () => await ListProfilesAsync());
 
-        var switchProfileCommand = new Command("switch", "Switch to a different profile");
-        var profileNameArg = new Argument<string>("name", "Profile name to switch to");
+        var switchProfileCommand = new Command("switch", "Switch to a different profile")
+        {
+            Description = "Change the active profile to use a different set of credentials and authentication. " +
+                         "The profile must already exist (created via 'config set --profile <name>')."
+        };
+        var profileNameArg = new Argument<string>("name", "Name of the profile to switch to");
         switchProfileCommand.AddArgument(profileNameArg);
         switchProfileCommand.SetHandler(async (string name) => await SwitchProfileAsync(name), profileNameArg);
 
         profilesCommand.AddCommand(listProfilesCommand);
         profilesCommand.AddCommand(switchProfileCommand);
 
-        var authCommand = new Command("auth", "Authenticate with GoToWebinar");
+        var authCommand = new Command("auth", "Authenticate with GoToWebinar using OAuth2 flow")
+        {
+            Description = "Opens your browser to authenticate with GoToWebinar. " +
+                         "Requires client ID and secret to be configured first via 'config set'. " +
+                         "The OAuth callback will be handled on http://localhost:7878/callback"
+        };
         authCommand.SetHandler(async () => await AuthenticateAsync());
 
         AddCommand(setCommand);


### PR DESCRIPTION
## Summary
- Fixed incorrect OAuth redirect port in README documentation (was 8080, should be 7878)
- Significantly improved help text for authentication and configuration commands
- Added clear guidance about OAuth flow and prerequisites

## Changes
1. **README.md**: Corrected the redirect URI port from 8080 to 7878 to match the actual port used by the CLI authentication service
2. **ConfigCommand.cs**: Enhanced help descriptions for all config subcommands:
   - Added detailed OAuth2 flow explanation to auth command
   - Included callback URL (http://localhost:7878/callback) in help text
   - Clarified prerequisites (need client ID/secret configured first)
   - Improved descriptions for set, test, get, and profiles commands
   - Added link to GoTo Developer Center in main config description

## Test Plan
- [x] Built the project successfully with `dotnet build`
- [x] Verified help text displays correctly with `gotowebinar config --help`
- [x] Confirmed auth-specific help with `gotowebinar config auth --help`
- [x] All existing tests pass