### PR TITLE
Fix registrant list JSON parsing error for numeric registrantKey

### DIFF
--- a/src/GoToWebinarCLI/Helpers/OutputFormatter.cs
+++ b/src/GoToWebinarCLI/Helpers/OutputFormatter.cs
@@ -145,7 +145,7 @@ public static class OutputFormatter
                 "Subject" when item is Models.Webinar w => w.Subject,
                 "TimeZone" when item is Models.Webinar w => w.TimeZone,
                 "InSession" when item is Models.Webinar w => w.InSession.ToString(),
-                "RegistrantKey" when item is Models.Registrant r => r.RegistrantKey,
+                "RegistrantKey" when item is Models.Registrant r => r.RegistrantKey.ToString(),
                 "FirstName" when item is Models.Registrant r => r.FirstName,
                 "LastName" when item is Models.Registrant r => r.LastName,
                 "Email" when item is Models.Registrant r => r.Email,

--- a/src/GoToWebinarCLI/Models/Registrant.cs
+++ b/src/GoToWebinarCLI/Models/Registrant.cs
@@ -5,7 +5,8 @@ namespace GoToWebinarCLI.Models;
 public sealed class Registrant
 {
     [JsonPropertyName("registrantKey")]
-    public string RegistrantKey { get; set; } = string.Empty;
+    [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString | JsonNumberHandling.WriteAsString)]
+    public long RegistrantKey { get; set; }
 
     [JsonPropertyName("firstName")]
     public string FirstName { get; set; } = string.Empty;

--- a/tests/GoToWebinarCLI.Tests/Commands/RegistrantCommandTests.cs
+++ b/tests/GoToWebinarCLI.Tests/Commands/RegistrantCommandTests.cs
@@ -62,19 +62,19 @@ public class RegistrantCommandTests
     public async Task GetCommand_WithValidKey_ShouldReturnRegistrantDetails()
     {
         // Arrange
-        var registrant = TestDataBuilder.CreateRegistrant("reg-123");
+        var registrant = TestDataBuilder.CreateRegistrant(1234567890123L);
         _mockApiClient.Setup(x => x.GetRegistrantAsync(
                 _testWebinarKey,
-                "reg-123",
+                "1234567890123",
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(registrant);
 
         // Act
-        var result = await _mockApiClient.Object.GetRegistrantAsync(_testWebinarKey, "reg-123");
+        var result = await _mockApiClient.Object.GetRegistrantAsync(_testWebinarKey, "1234567890123");
 
         // Assert
         result.Should().NotBeNull();
-        result!.RegistrantKey.Should().Be("reg-123");
+        result!.RegistrantKey.Should().Be(1234567890123L);
         result.FirstName.Should().Be("Jane");
         result.LastName.Should().Be("Smith");
         result.Email.Should().Be("jane.smith@example.com");
@@ -114,7 +114,7 @@ public class RegistrantCommandTests
 
         var createdRegistrant = new Registrant
         {
-            RegistrantKey = "new-reg-456",
+            RegistrantKey = 4567890123456789L,
             FirstName = request.FirstName,
             LastName = request.LastName,
             Email = request.Email,

--- a/tests/GoToWebinarCLI.Tests/Helpers/TestDataBuilder.cs
+++ b/tests/GoToWebinarCLI.Tests/Helpers/TestDataBuilder.cs
@@ -97,7 +97,7 @@ public static class TestDataBuilder
         {
             registrants.Add(new Registrant
             {
-                RegistrantKey = $"registrant-{i + 1}",
+                RegistrantKey = 1000000000000000000L + i + 1,
                 FirstName = $"John{i + 1}",
                 LastName = $"Doe{i + 1}",
                 Email = $"john.doe{i + 1}@example.com",
@@ -112,7 +112,7 @@ public static class TestDataBuilder
         return registrants;
     }
 
-    public static Registrant CreateRegistrant(string key = "test-registrant-1")
+    public static Registrant CreateRegistrant(long key = 1234567890123456789L)
     {
         return new Registrant
         {

--- a/tests/GoToWebinarCLI.Tests/Serialization/JsonSerializationTests.cs
+++ b/tests/GoToWebinarCLI.Tests/Serialization/JsonSerializationTests.cs
@@ -159,7 +159,7 @@ public class JsonSerializationTests
         // Arrange
         var registrant = new Registrant
         {
-            RegistrantKey = "reg-123",
+            RegistrantKey = 1234567890123456789L,
             Email = "test@example.com",
             FirstName = "John",
             LastName = "Doe",
@@ -197,6 +197,60 @@ public class JsonSerializationTests
         deserialized.NumberOfEmployees.Should().Be(registrant.NumberOfEmployees);
         deserialized.PurchasingTimeFrame.Should().Be(registrant.PurchasingTimeFrame);
         deserialized.PurchasingRole.Should().Be(registrant.PurchasingRole);
+    }
+
+    [Fact]
+    public void Registrant_Deserialization_HandlesNumericRegistrantKey()
+    {
+        // Arrange - This simulates the actual API response where registrantKey is a number
+        // See: https://github.com/Aaronontheweb/gotowebinar-cli/issues/58
+        var json = @"{
+            ""registrantKey"": 6636963798794335320,
+            ""firstName"": ""John"",
+            ""lastName"": ""Doe"",
+            ""email"": ""john.doe@example.com"",
+            ""registrationDate"": ""2026-01-07T15:30:00Z"",
+            ""status"": ""PENDING"",
+            ""joinUrl"": ""https://global.gotowebinar.com/join/123456"",
+            ""organization"": ""Acme Corp"",
+            ""jobTitle"": ""Developer""
+        }";
+
+        // Act
+        var deserialized = JsonSerializer.Deserialize(json, _jsonContext.Registrant);
+
+        // Assert
+        deserialized.Should().NotBeNull();
+        deserialized!.RegistrantKey.Should().Be(6636963798794335320L);
+        deserialized.FirstName.Should().Be("John");
+        deserialized.LastName.Should().Be("Doe");
+        deserialized.Email.Should().Be("john.doe@example.com");
+        deserialized.Status.Should().Be("PENDING");
+        deserialized.Organization.Should().Be("Acme Corp");
+        deserialized.JobTitle.Should().Be("Developer");
+    }
+
+    [Fact]
+    public void Registrant_Deserialization_HandlesStringRegistrantKey()
+    {
+        // Arrange - Also verify backwards compatibility with string keys if API ever returns them
+        var json = @"{
+            ""registrantKey"": ""6636963798794335320"",
+            ""firstName"": ""Jane"",
+            ""lastName"": ""Smith"",
+            ""email"": ""jane.smith@example.com"",
+            ""registrationDate"": ""2026-01-07T15:30:00Z"",
+            ""status"": ""APPROVED""
+        }";
+
+        // Act
+        var deserialized = JsonSerializer.Deserialize(json, _jsonContext.Registrant);
+
+        // Assert
+        deserialized.Should().NotBeNull();
+        deserialized!.RegistrantKey.Should().Be(6636963798794335320L);
+        deserialized.FirstName.Should().Be("Jane");
+        deserialized.LastName.Should().Be("Smith");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Fixes #58 - The `gotowebinar registrant list <webinar-key>` command was failing with a JSON parsing error because the GoToWebinar API returns `registrantKey` as a numeric value (long integer), but the model expected a string.

## Changes

- Changed `RegistrantKey` property from `string` to `long` in the `Registrant` model
- Added `JsonNumberHandling` attribute to handle both numeric and string formats from the API
- Updated `OutputFormatter` to convert `RegistrantKey` to string for display
- Updated all related tests to use `long` values
- Added specific unit tests for:
  - Numeric `registrantKey` deserialization (the actual API format)
  - String `registrantKey` deserialization (backwards compatibility)

## Test Plan

- [x] All existing tests pass (37/37)
- [x] New tests verify numeric registrantKey is correctly deserialized
- [x] New tests verify string registrantKey also works for backwards compatibility