### PR TITLE
Upgrade to .NET 10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: '9.0.x'
+        dotnet-version: '10.0.x'
         
     - name: Restore dependencies
       run: dotnet restore GoToWebinarCLI.sln

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: '9.0.x'
+        dotnet-version: '10.0.x'
         
     - name: Restore dependencies
       run: dotnet restore
@@ -153,7 +153,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '9.0.x'
+          dotnet-version: '10.0.x'
           
       - name: Update version and make packable
         shell: pwsh

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -35,7 +35,7 @@
     <!-- Visual Studio C# settings -->
     <NetStandardLibVersion>netstandard2.0</NetStandardLibVersion>
     <NetLibVersion>net6.0</NetLibVersion>
-    <NetCoreTestVersion>net9.0</NetCoreTestVersion>
+    <NetCoreTestVersion>net10.0</NetCoreTestVersion>
   </PropertyGroup>
   <!-- Removed Akka.Event global using as it's not needed for this project -->
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "9.0.300",
+        "version": "10.0.100",
         "rollForward": "latestPatch"
     }
 } 

--- a/src/GoToWebinarCLI/GoToWebinarCLI.csproj
+++ b/src/GoToWebinarCLI/GoToWebinarCLI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AssemblyName>gotowebinar</AssemblyName>
@@ -29,7 +29,6 @@
     <!-- Core Dependencies for CLI -->
     <PackageReference Include="System.CommandLine" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" />
-    <PackageReference Include="System.Text.Json" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" />
   </ItemGroup>
 

--- a/tests/GoToWebinarCLI.Tests/GoToWebinarCLI.Tests.csproj
+++ b/tests/GoToWebinarCLI.Tests/GoToWebinarCLI.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
## Summary
- Upgrade target framework from .NET 9 to .NET 10
- Update SDK version from 9.0.300 to 10.0.100
- Update GitHub Actions workflows to use .NET 10.0.x
- Remove explicit System.Text.Json package reference (now built into .NET 10)

## Test plan
- [x] Verified local build succeeds
- [x] Verified all 37 tests pass
- [ ] CI builds pass on Ubuntu, Windows, and macOS
- [ ] AOT compilation works correctly